### PR TITLE
Explicitly log Doppler metadata rather than relying on prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## 0.1.0 (July 22, 2022)
+## 0.1.0 (Aug 4, 2022)
 
 - Initial release

--- a/lib/doppler-env.rb
+++ b/lib/doppler-env.rb
@@ -31,7 +31,7 @@ module DopplerEnv
       ENV[k] ||= v
     end
     log "Secrets loaded successfully:"
-    log "  #{ENV.select{|k,v| k.start_with?("DOPPLER") && k != "DOPPLER_TOKEN"}}"
+    log "  project=#{ENV["DOPPLER_PROJECT"]} config=#{ENV["DOPPLER_CONFIG"]} environment=#{ENV["DOPPLER_ENVIRONMENT"]}"
   end
 
   # loads secrets into ENV, overwriting any variables that already exist
@@ -40,7 +40,7 @@ module DopplerEnv
       ENV[k] = v
     end
     log "Secrets loaded successfully:"
-    log "  #{ENV.select{|k,v| k.start_with?("DOPPLER") && k != "DOPPLER_TOKEN"}}"
+    log "  project=#{ENV["DOPPLER_PROJECT"]} config=#{ENV["DOPPLER_CONFIG"]} environment=#{ENV["DOPPLER_ENVIRONMENT"]}"
   end
 
   # this method expects `doppler setup` to have already been run


### PR DESCRIPTION
We were logging variables starting with `DOPPLER` (aside from `DOPPLER_TOKEN`), but it's safer to just explicitly log the Doppler metadata we want.